### PR TITLE
Auto-connect on init

### DIFF
--- a/ace.cfg
+++ b/ace.cfg
@@ -5,7 +5,6 @@ filename: {config_path}/ace_vars.cfg
 [respond]
 
 [ace]
-serial: /dev/serial/by-id/usb-ANYCUBIC_ACE_1-if00
 baud: 115200
 # Extruder_sensor_pin
 extruder_sensor_pin: #insert the sensor pin

--- a/extras/ace.py
+++ b/extras/ace.py
@@ -333,7 +333,6 @@ class BunnyAce:
         return self._request_id
     
     def _get_serial_id(self):
-        # These are placeholders. 
         _vid = 0x018A
         _pid = 0x28E9
 

--- a/extras/ace.py
+++ b/extras/ace.py
@@ -155,7 +155,7 @@ class BunnyAce:
         else:
             config.error("There is no [save_variables] in the config. Check installation guide")
 
-        self.serial_id = config.get('serial', '/dev/ttyACM0')
+        self.serial_id = self._get_serial_id()
         self.baud = config.getint('baud', 115200)
         extruder_sensor_pin = config.get('extruder_sensor_pin')
         toolhead_sensor_pin = config.get('toolhead_sensor_pin', None)
@@ -274,6 +274,7 @@ class BunnyAce:
         self._main_queue = queue.Queue()
         self.connect_timer = self.reactor.register_timer(self._connect, self.reactor.NOW)
 
+    
     def _handle_disconnect(self):
         logging.info('ACE: Closing connection to ' + self.serial_id)
         self._serial.close()
@@ -330,6 +331,16 @@ class BunnyAce:
         if self._request_id >= 300000:
             self._request_id = 0
         return self._request_id
+    
+    def _get_serial_id(self):
+        # These are placeholders. 
+        _vid = 0x0000
+        _pid = 0x0000
+
+        _ports = serial.tools.list_ports.comports()
+        for _port in _ports:
+            if _port.vid == _vid and _port.pid ==_pid:
+                return _port.device
 
     def _serial_disconnect(self):
 

--- a/extras/ace.py
+++ b/extras/ace.py
@@ -334,8 +334,8 @@ class BunnyAce:
     
     def _get_serial_id(self):
         # These are placeholders. 
-        _vid = 0x0000
-        _pid = 0x0000
+        _vid = 0x018A
+        _pid = 0x28E9
 
         _ports = serial.tools.list_ports.comports()
         for _port in _ports:


### PR DESCRIPTION
I tested this on the stable branch first before porting it to the dev branch. 

This is my first pull request. Ever. So.... If I've done anything wrong. I apologies in advance 

Connect with the first serial connection that matches VID/PID of the anycubic ACE PRO

This does open up the question of multiple ACE's on the same machine and how to handle that.

Also using pyudev for hotswapping USBs. I think klipper has a stance against this because of how wide and varied hardware is. 

BUT

This is a driver for a very specific hardware. 